### PR TITLE
fix(auth): merge duplicate cas accounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/migrations/20260804_merge_cas_duplicate_users.sql
+++ b/migrations/20260804_merge_cas_duplicate_users.sql
@@ -1,0 +1,182 @@
+-- One-off migration for duplicate local/CAS accounts.
+--
+-- Run migrations/20260804_preview_cas_duplicate_users.sql first and take a
+-- database backup before applying this file.
+--
+-- This migration only merges unambiguous CAS shadow accounts into existing
+-- local accounts:
+--   1. A CAS shadow account is a user currently bound by provider = 'cas'
+--      whose username starts with 'cas_'.
+--   2. Prefer a non-shadow local account with the same CAS email.
+--   3. Fall back to a non-shadow local account whose username equals the CAS
+--      provider_subject.
+--   4. Ambiguous matches are skipped and must be handled manually.
+
+START TRANSACTION;
+
+DROP TEMPORARY TABLE IF EXISTS cas_user_merge_candidates;
+
+CREATE TEMPORARY TABLE cas_user_merge_candidates AS
+SELECT
+  ui.id AS identity_id,
+  ui.provider_subject AS cas_subject,
+  ui.email AS identity_email,
+  shadow.id AS shadow_user_id,
+  shadow.username AS shadow_username,
+  shadow.email AS shadow_email,
+  target.id AS target_user_id,
+  target.username AS target_username,
+  target.email AS target_email,
+  'email' AS matched_by,
+  1 AS match_rank
+FROM user_identities ui
+JOIN users shadow ON shadow.id = ui.user_id
+JOIN users target
+  ON target.id <> shadow.id
+ AND target.email = COALESCE(NULLIF(ui.email, ''), NULLIF(shadow.email, ''))
+ AND LEFT(COALESCE(target.username, ''), 4) <> 'cas_'
+WHERE ui.provider = 'cas'
+  AND LEFT(COALESCE(shadow.username, ''), 4) = 'cas_'
+  AND COALESCE(NULLIF(ui.email, ''), NULLIF(shadow.email, '')) IS NOT NULL
+
+UNION ALL
+
+SELECT
+  ui.id AS identity_id,
+  ui.provider_subject AS cas_subject,
+  ui.email AS identity_email,
+  shadow.id AS shadow_user_id,
+  shadow.username AS shadow_username,
+  shadow.email AS shadow_email,
+  target.id AS target_user_id,
+  target.username AS target_username,
+  target.email AS target_email,
+  'username' AS matched_by,
+  2 AS match_rank
+FROM user_identities ui
+JOIN users shadow ON shadow.id = ui.user_id
+JOIN users target
+  ON target.id <> shadow.id
+ AND target.username = ui.provider_subject
+ AND LEFT(COALESCE(target.username, ''), 4) <> 'cas_'
+WHERE ui.provider = 'cas'
+  AND LEFT(COALESCE(shadow.username, ''), 4) = 'cas_'
+  AND ui.provider_subject <> '';
+
+DROP TEMPORARY TABLE IF EXISTS cas_user_merge_pairs;
+
+CREATE TEMPORARY TABLE cas_user_merge_pairs AS
+SELECT
+  c.identity_id,
+  c.shadow_user_id,
+  MIN(c.target_user_id) AS target_user_id,
+  MIN(c.matched_by) AS matched_by
+FROM cas_user_merge_candidates c
+JOIN (
+  SELECT identity_id, MIN(match_rank) AS match_rank
+  FROM cas_user_merge_candidates
+  GROUP BY identity_id
+) best ON best.identity_id = c.identity_id
+      AND best.match_rank = c.match_rank
+GROUP BY c.identity_id, c.shadow_user_id
+HAVING COUNT(DISTINCT c.target_user_id) = 1;
+
+UPDATE users target
+JOIN cas_user_merge_pairs p ON p.target_user_id = target.id
+JOIN users shadow ON shadow.id = p.shadow_user_id
+SET
+  target.email = CASE
+    WHEN COALESCE(target.email, '') = '' THEN shadow.email
+    ELSE target.email
+  END,
+  target.info = CASE
+    WHEN COALESCE(target.info, '') = ''
+     AND COALESCE(shadow.info, '') <> 'cas authenticated user'
+    THEN shadow.info
+    ELSE target.info
+  END,
+  target.avatar_url = CASE
+    WHEN COALESCE(target.avatar_url, '') = '' THEN shadow.avatar_url
+    ELSE target.avatar_url
+  END,
+  target.personal_blog = CASE
+    WHEN COALESCE(target.personal_blog, '') = '' THEN shadow.personal_blog
+    ELSE target.personal_blog
+  END,
+  target.github = CASE
+    WHEN COALESCE(target.github, '') = '' THEN shadow.github
+    ELSE target.github
+  END,
+  target.flickr = CASE
+    WHEN COALESCE(target.flickr, '') = '' THEN shadow.flickr
+    ELSE target.flickr
+  END,
+  target.weibo = CASE
+    WHEN COALESCE(target.weibo, '') = '' THEN shadow.weibo
+    ELSE target.weibo
+  END,
+  target.zhihu = CASE
+    WHEN COALESCE(target.zhihu, '') = '' THEN shadow.zhihu
+    ELSE target.zhihu
+  END,
+  target.birthday = CASE
+    WHEN COALESCE(target.birthday, '') = '' THEN shadow.birthday
+    ELSE target.birthday
+  END,
+  target.`group` = CASE
+    WHEN COALESCE(target.`group`, '') = '' THEN shadow.`group`
+    ELSE target.`group`
+  END,
+  target.hometown = CASE
+    WHEN COALESCE(target.hometown, '') = '' THEN shadow.hometown
+    ELSE target.hometown
+  END,
+  target.timejoin = CASE
+    WHEN COALESCE(target.timejoin, '') = '' THEN shadow.timejoin
+    ELSE target.timejoin
+  END;
+
+UPDATE user_identities ui
+JOIN cas_user_merge_pairs p ON p.identity_id = ui.id
+SET ui.user_id = p.target_user_id;
+
+SET @oauth2_token_exists := (
+  SELECT COUNT(*)
+  FROM information_schema.tables
+  WHERE table_schema = DATABASE()
+    AND table_name = 'oauth2_token'
+);
+
+SET @rewrite_oauth2_token_sql := IF(
+  @oauth2_token_exists > 0,
+  'UPDATE oauth2_token t
+   JOIN cas_user_merge_pairs p
+     ON JSON_VALID(t.data) = 1
+    AND JSON_UNQUOTE(JSON_EXTRACT(t.data, ''$.UserID'')) = CAST(p.shadow_user_id AS CHAR)
+   SET t.data = JSON_SET(t.data, ''$.UserID'', CAST(p.target_user_id AS CHAR))',
+  'SELECT ''oauth2_token table not found; skipped token rewrite'' AS note'
+);
+
+PREPARE rewrite_oauth2_token FROM @rewrite_oauth2_token_sql;
+EXECUTE rewrite_oauth2_token;
+DEALLOCATE PREPARE rewrite_oauth2_token;
+
+DELETE shadow
+FROM users shadow
+JOIN (
+  SELECT DISTINCT shadow_user_id
+  FROM cas_user_merge_pairs
+) merged ON merged.shadow_user_id = shadow.id
+LEFT JOIN user_identities remaining ON remaining.user_id = shadow.id
+WHERE remaining.id IS NULL;
+
+SELECT COUNT(*) AS merged_identity_count
+FROM cas_user_merge_pairs;
+
+SELECT c.*
+FROM cas_user_merge_candidates c
+LEFT JOIN cas_user_merge_pairs p ON p.identity_id = c.identity_id
+WHERE p.identity_id IS NULL
+ORDER BY c.identity_id, c.match_rank, c.target_user_id;
+
+COMMIT;

--- a/migrations/20260804_preview_cas_duplicate_users.sql
+++ b/migrations/20260804_preview_cas_duplicate_users.sql
@@ -1,0 +1,98 @@
+-- Preview duplicate local/CAS accounts before running the merge migration.
+-- Rule:
+--   1. A CAS shadow account is a user currently bound by provider = 'cas'
+--      whose username starts with 'cas_'.
+--   2. Prefer a non-shadow local account with the same CAS email.
+--   3. Fall back to a non-shadow local account whose username equals the CAS
+--      provider_subject.
+--   4. Only identities with exactly one best target are merged by the apply
+--      script. Ambiguous rows must be handled manually.
+
+DROP TEMPORARY TABLE IF EXISTS cas_user_merge_candidates;
+
+CREATE TEMPORARY TABLE cas_user_merge_candidates AS
+SELECT
+  ui.id AS identity_id,
+  ui.provider_subject AS cas_subject,
+  ui.email AS identity_email,
+  shadow.id AS shadow_user_id,
+  shadow.username AS shadow_username,
+  shadow.email AS shadow_email,
+  target.id AS target_user_id,
+  target.username AS target_username,
+  target.email AS target_email,
+  'email' AS matched_by,
+  1 AS match_rank
+FROM user_identities ui
+JOIN users shadow ON shadow.id = ui.user_id
+JOIN users target
+  ON target.id <> shadow.id
+ AND target.email = COALESCE(NULLIF(ui.email, ''), NULLIF(shadow.email, ''))
+ AND LEFT(COALESCE(target.username, ''), 4) <> 'cas_'
+WHERE ui.provider = 'cas'
+  AND LEFT(COALESCE(shadow.username, ''), 4) = 'cas_'
+  AND COALESCE(NULLIF(ui.email, ''), NULLIF(shadow.email, '')) IS NOT NULL
+
+UNION ALL
+
+SELECT
+  ui.id AS identity_id,
+  ui.provider_subject AS cas_subject,
+  ui.email AS identity_email,
+  shadow.id AS shadow_user_id,
+  shadow.username AS shadow_username,
+  shadow.email AS shadow_email,
+  target.id AS target_user_id,
+  target.username AS target_username,
+  target.email AS target_email,
+  'username' AS matched_by,
+  2 AS match_rank
+FROM user_identities ui
+JOIN users shadow ON shadow.id = ui.user_id
+JOIN users target
+  ON target.id <> shadow.id
+ AND target.username = ui.provider_subject
+ AND LEFT(COALESCE(target.username, ''), 4) <> 'cas_'
+WHERE ui.provider = 'cas'
+  AND LEFT(COALESCE(shadow.username, ''), 4) = 'cas_'
+  AND ui.provider_subject <> '';
+
+DROP TEMPORARY TABLE IF EXISTS cas_user_merge_pairs;
+
+CREATE TEMPORARY TABLE cas_user_merge_pairs AS
+SELECT
+  c.identity_id,
+  c.cas_subject,
+  c.identity_email,
+  c.shadow_user_id,
+  c.shadow_username,
+  c.shadow_email,
+  MIN(c.target_user_id) AS target_user_id,
+  MIN(c.target_username) AS target_username,
+  MIN(c.target_email) AS target_email,
+  MIN(c.matched_by) AS matched_by
+FROM cas_user_merge_candidates c
+JOIN (
+  SELECT identity_id, MIN(match_rank) AS match_rank
+  FROM cas_user_merge_candidates
+  GROUP BY identity_id
+) best ON best.identity_id = c.identity_id
+      AND best.match_rank = c.match_rank
+GROUP BY
+  c.identity_id,
+  c.cas_subject,
+  c.identity_email,
+  c.shadow_user_id,
+  c.shadow_username,
+  c.shadow_email
+HAVING COUNT(DISTINCT c.target_user_id) = 1;
+
+SELECT *
+FROM cas_user_merge_pairs
+ORDER BY identity_id;
+
+SELECT c.*
+FROM cas_user_merge_candidates c
+LEFT JOIN cas_user_merge_pairs p ON p.identity_id = c.identity_id
+WHERE p.identity_id IS NULL
+ORDER BY c.identity_id, c.match_rank, c.target_user_id;

--- a/service/cas_identity.go
+++ b/service/cas_identity.go
@@ -38,6 +38,28 @@ func (r *defaultCASUserResolver) ResolveCASUser(_ context.Context, authenticatio
 		return 0, tx.Error
 	}
 
+	if existingUser, err := findExistingLocalUserForCAS(tx, casUsername, email); err != nil {
+		tx.Rollback()
+		return 0, err
+	} else if existingUser != nil {
+		identity = &model.UserIdentity{
+			UserID:          existingUser.Id,
+			Provider:        casIdentityProvider,
+			ProviderSubject: casUsername,
+			Email:           email,
+		}
+		if err := tx.Create(identity).Error; err != nil {
+			tx.Rollback()
+			return 0, err
+		}
+
+		if err := tx.Commit().Error; err != nil {
+			tx.Rollback()
+			return 0, err
+		}
+		return existingUser.Id, nil
+	}
+
 	user := &model.UserModel{
 		Email:        email,
 		Username:     BuildCASLocalUsername(casUsername),
@@ -67,6 +89,29 @@ func (r *defaultCASUserResolver) ResolveCASUser(_ context.Context, authenticatio
 		return 0, err
 	}
 	return user.Id, nil
+}
+
+func findExistingLocalUserForCAS(tx *gorm.DB, casUsername, email string) (*model.UserModel, error) {
+	if email != "" {
+		user := &model.UserModel{}
+		err := tx.Where("email = ? AND username NOT LIKE ?", email, "cas\\_%").Order("id ASC").First(user).Error
+		if err == nil {
+			return user, nil
+		}
+		if !gorm.IsRecordNotFoundError(err) {
+			return nil, err
+		}
+	}
+
+	user := &model.UserModel{}
+	err := tx.Where("username = ?", casUsername).Order("id ASC").First(user).Error
+	if err == nil {
+		return user, nil
+	}
+	if !gorm.IsRecordNotFoundError(err) {
+		return nil, err
+	}
+	return nil, nil
 }
 
 func BuildCASLocalUsername(casUsername string) string {

--- a/service/cas_identity.go
+++ b/service/cas_identity.go
@@ -94,7 +94,7 @@ func (r *defaultCASUserResolver) ResolveCASUser(_ context.Context, authenticatio
 func findExistingLocalUserForCAS(tx *gorm.DB, casUsername, email string) (*model.UserModel, error) {
 	if email != "" {
 		user := &model.UserModel{}
-		err := tx.Where("email = ? AND username NOT LIKE ?", email, "cas\\_%").Order("id ASC").First(user).Error
+		err := tx.Where("email = ? AND SUBSTR(username, 1, 4) <> ?", email, "cas_").Order("id ASC").First(user).Error
 		if err == nil {
 			return user, nil
 		}
@@ -104,7 +104,7 @@ func findExistingLocalUserForCAS(tx *gorm.DB, casUsername, email string) (*model
 	}
 
 	user := &model.UserModel{}
-	err := tx.Where("username = ?", casUsername).Order("id ASC").First(user).Error
+	err := tx.Where("username = ? AND SUBSTR(username, 1, 4) <> ?", casUsername, "cas_").Order("id ASC").First(user).Error
 	if err == nil {
 		return user, nil
 	}

--- a/service/cas_identity_test.go
+++ b/service/cas_identity_test.go
@@ -1,6 +1,135 @@
 package service
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/Muxi-X/muxi_auth_service_v2/model"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	cas "gopkg.in/cas.v2"
+)
+
+func setupCASIdentityTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open test database failed: %v", err)
+	}
+	db.LogMode(false)
+	if err := db.AutoMigrate(&model.UserModel{}, &model.UserIdentity{}).Error; err != nil {
+		db.Close()
+		t.Fatalf("migrate test database failed: %v", err)
+	}
+
+	oldDB := model.DB
+	model.DB = &model.Database{Self: db}
+	t.Cleanup(func() {
+		model.DB = oldDB
+		db.Close()
+	})
+
+	return db
+}
+
+func TestResolveCASUserBindsExistingLocalUserByEmail(t *testing.T) {
+	db := setupCASIdentityTestDB(t)
+	existingUser := &model.UserModel{
+		Email:    "alice@example.com",
+		Username: "alice",
+		RoleID:   3,
+	}
+	if err := db.Create(existingUser).Error; err != nil {
+		t.Fatalf("create existing user failed: %v", err)
+	}
+
+	userID, err := (&defaultCASUserResolver{}).ResolveCASUser(context.Background(), &cas.AuthenticationResponse{
+		User:       "alice.cas",
+		Attributes: cas.UserAttributes{"email": []string{"alice@example.com"}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveCASUser returned error: %v", err)
+	}
+	if userID != existingUser.Id {
+		t.Fatalf("expected existing user id %d, got %d", existingUser.Id, userID)
+	}
+	assertUserCount(t, db, 1)
+	assertCASIdentity(t, db, "alice.cas", existingUser.Id)
+}
+
+func TestResolveCASUserBindsExistingLocalUserByUsername(t *testing.T) {
+	db := setupCASIdentityTestDB(t)
+	existingUser := &model.UserModel{
+		Email:    "bob@example.com",
+		Username: "bob",
+		RoleID:   3,
+	}
+	if err := db.Create(existingUser).Error; err != nil {
+		t.Fatalf("create existing user failed: %v", err)
+	}
+
+	userID, err := (&defaultCASUserResolver{}).ResolveCASUser(context.Background(), &cas.AuthenticationResponse{
+		User: "bob",
+	})
+	if err != nil {
+		t.Fatalf("ResolveCASUser returned error: %v", err)
+	}
+	if userID != existingUser.Id {
+		t.Fatalf("expected existing user id %d, got %d", existingUser.Id, userID)
+	}
+	assertUserCount(t, db, 1)
+	assertCASIdentity(t, db, "bob", existingUser.Id)
+}
+
+func TestResolveCASUserDoesNotBindExistingCASShadowUserByUsername(t *testing.T) {
+	db := setupCASIdentityTestDB(t)
+	shadowUser := &model.UserModel{
+		Email:    "carol@example.com",
+		Username: "cas_carol_shadow",
+		RoleID:   3,
+	}
+	if err := db.Create(shadowUser).Error; err != nil {
+		t.Fatalf("create shadow user failed: %v", err)
+	}
+
+	userID, err := (&defaultCASUserResolver{}).ResolveCASUser(context.Background(), &cas.AuthenticationResponse{
+		User: "cas_carol_shadow",
+	})
+	if err != nil {
+		t.Fatalf("ResolveCASUser returned error: %v", err)
+	}
+	if userID == shadowUser.Id {
+		t.Fatalf("expected resolver not to bind shadow user id %d", shadowUser.Id)
+	}
+	assertUserCount(t, db, 2)
+	assertCASIdentity(t, db, "cas_carol_shadow", userID)
+}
+
+func assertUserCount(t *testing.T, db *gorm.DB, want int) {
+	t.Helper()
+
+	var count int
+	if err := db.Model(&model.UserModel{}).Count(&count).Error; err != nil {
+		t.Fatalf("count users failed: %v", err)
+	}
+	if count != want {
+		t.Fatalf("expected %d users, got %d", want, count)
+	}
+}
+
+func assertCASIdentity(t *testing.T, db *gorm.DB, providerSubject string, wantUserID uint64) {
+	t.Helper()
+
+	identity := &model.UserIdentity{}
+	err := db.Where("provider = ? AND provider_subject = ?", casIdentityProvider, providerSubject).First(identity).Error
+	if err != nil {
+		t.Fatalf("get CAS identity failed: %v", err)
+	}
+	if identity.UserID != wantUserID {
+		t.Fatalf("expected identity user id %d, got %d", wantUserID, identity.UserID)
+	}
+}
 
 func TestBuildCASLocalUsername(t *testing.T) {
 	got := BuildCASLocalUsername(" Alice.Z ")


### PR DESCRIPTION
## Summary
- bind first-time CAS logins to existing local accounts by email or matching username
- add preview and apply SQL migrations for merging historical CAS shadow accounts
- rewrite CAS identity ownership and OAuth token user IDs during the merge

## Validation
- GOCACHE=/private/tmp/muxi_auth_go_cache go test ./service ./model ./pkg/oauth ./handler/user ./router/middleware

## Notes
- Run the preview SQL and take a database backup before applying the merge migration. Ambiguous matches are reported but skipped.